### PR TITLE
Modified `MoveAxesAsync` to enable multi-axis movement.

### DIFF
--- a/source/MoonrakerSharpWebApi/MoonrakerSharpWebApi/MoonrakerClient.cs
+++ b/source/MoonrakerSharpWebApi/MoonrakerSharpWebApi/MoonrakerClient.cs
@@ -5654,11 +5654,16 @@ namespace AndreasReitberger.API.Moonraker
             try
             {
                 //string gcode = $"G1 X+10 F{Speed}";
+                var axes = new[] {x, y, z};
                 StringBuilder gcodeCommand = new();
-                if (x != double.PositiveInfinity) gcodeCommand.Append($"G1 X{(relative ? "" : "+")}{x} F{speed};");
-                if (y != double.PositiveInfinity) gcodeCommand.Append($"G1 Y{(relative ? "" : "+")}{y} F{speed};");
-                if (z != double.PositiveInfinity) gcodeCommand.Append($"G1 Z{(relative ? "" : "+")}{z} F{speed};");
+                var anyAxesMoves = axes.Any(a => a != double.PositiveInfinity);
+                if (anyAxesMoves) gcodeCommand.Append($"G1 F{speed}");
+                if (x != double.PositiveInfinity) gcodeCommand.Append($" X{(relative ? "" : "+")}{x}");
+                if (y != double.PositiveInfinity) gcodeCommand.Append($" Y{(relative ? "" : "+")}{y}");
+                if (z != double.PositiveInfinity) gcodeCommand.Append($" Z{(relative ? "" : "+")}{z}");
+                if (anyAxesMoves) gcodeCommand.Append("\n"); // add new line to end command string
                 if (e != double.PositiveInfinity) gcodeCommand.Append($"M83\nG1 E{e} F{speed};");
+                
 
                 bool result = await RunGcodeScriptAsync(gcodeCommand.ToString()).ConfigureAwait(false);
                 return result;

--- a/source/MoonrakerSharpWebApi/MoonrakerSharpWebApiTest/MoonrakerSharpWebApiTest.cs
+++ b/source/MoonrakerSharpWebApi/MoonrakerSharpWebApiTest/MoonrakerSharpWebApiTest.cs
@@ -23,11 +23,9 @@ namespace RepetierServerSharpApiTest
     public class MoonrakerSharpWebApiTest
     {
 
-        // private readonly string _host = "192.168.10.113";
-        private readonly string _host = "192.168.0.108";
+        private readonly string _host = "192.168.10.113";
         private readonly int _port = 80;
-        // private readonly string _api = "1c8fc5833641429a95d00991e1f3aa0f";
-        private readonly string _api = "";
+        private readonly string _api = "1c8fc5833641429a95d00991e1f3aa0f";
         private readonly bool _ssl = false;
 
         private readonly bool _skipOnlineTests = true;

--- a/source/MoonrakerSharpWebApi/MoonrakerSharpWebApiTest/MoonrakerSharpWebApiTest.cs
+++ b/source/MoonrakerSharpWebApi/MoonrakerSharpWebApiTest/MoonrakerSharpWebApiTest.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 
 namespace RepetierServerSharpApiTest
 {
@@ -22,9 +23,11 @@ namespace RepetierServerSharpApiTest
     public class MoonrakerSharpWebApiTest
     {
 
-        private readonly string _host = "192.168.10.113";
+        // private readonly string _host = "192.168.10.113";
+        private readonly string _host = "192.168.0.108";
         private readonly int _port = 80;
-        private readonly string _api = "1c8fc5833641429a95d00991e1f3aa0f";
+        // private readonly string _api = "1c8fc5833641429a95d00991e1f3aa0f";
+        private readonly string _api = "";
         private readonly bool _ssl = false;
 
         private readonly bool _skipOnlineTests = true;
@@ -460,11 +463,42 @@ namespace RepetierServerSharpApiTest
                     await _server.RefreshAllAsync();
                     Assert.IsTrue(_server.InitialDataFetched);
 
-                    bool homed = await _server.HomeAxesAsync(true, true, true);
-                    Assert.IsTrue(homed);
-
-                    bool moved = await _server.MoveAxesAsync(6000, 100);
-                    Assert.IsTrue(moved);
+                    var homed = await _server.HomeAxesAsync(true, true, true);
+                    Assert.IsTrue(homed, "Not homed!");
+                    
+                    // Move all 3 axes to ensure they all move correctly
+                    var newX = 100;
+                    var newY = 100;
+                    var newZ = 100;
+                    var moved = await _server.MoveAxesAsync(
+                        speed: 6000, 
+                        x: newX, 
+                        y: newY, 
+                        z: newZ,
+                        relative: false);
+                    var end = await _server.GetToolHeadStatusAsync();
+                    Assert.IsTrue(moved, "Did not move");
+                    Assert.AreEqual(newX, end.Position[0], message: "X didn't move as expected");
+                    Assert.AreEqual(newY, end.Position[1], message: "Y didn't move as expected");
+                    Assert.AreEqual(newZ, end.Position[2], message: "Z didn't move as expected");
+                    
+                    // Move all 3 axes independently to make sure they move as expected
+                    newX = 50;
+                    newY = 50;
+                    newZ = 50;
+                    await _server.MoveAxesAsync(
+                        speed: 6000, 
+                        x: newX);
+                    await _server.MoveAxesAsync(
+                        speed: 6000, 
+                        y: newY);
+                    await _server.MoveAxesAsync(
+                        speed: 6000, 
+                        z: newZ);
+                    end = await _server.GetToolHeadStatusAsync();
+                    Assert.AreEqual(newX, end.Position[0], message: "X didn't move as expected");
+                    Assert.AreEqual(newY, end.Position[1], message: "Y didn't move as expected");
+                    Assert.AreEqual(newZ, end.Position[2], message: "Z didn't move as expected");
                 }
                 else
                     Assert.Fail($"Server {_server.FullWebAddress} is offline.");
@@ -1391,12 +1425,12 @@ namespace RepetierServerSharpApiTest
                 {
                     foreach (var pair in args.ExtruderStates)
                     {
-                        Debug.WriteLine($"Extruder{pair.Key}: {pair.Value?.Temperature} °C (Target: {pair.Value?.Target} °C)");
+                        Debug.WriteLine($"Extruder{pair.Key}: {pair.Value?.Temperature} ï¿½C (Target: {pair.Value?.Target} ï¿½C)");
                     }
                 };
                 _server.KlipperHeaterBedStateChanged += (o, args) =>
                 {
-                    Debug.WriteLine($"HeatedBed: {args.NewHeaterBedState.Temperature} °C (Target: {args.NewHeaterBedState.Target} °C)");
+                    Debug.WriteLine($"HeatedBed: {args.NewHeaterBedState.Temperature} ï¿½C (Target: {args.NewHeaterBedState.Target} ï¿½C)");
                 };
                 _server.KlipperDisplayStatusChanged += (o, args) =>
                 {


### PR DESCRIPTION
As noted in issue #18, if you attempt a movement using `MoveAxesAsync`, only the x axis will move. I've updated the code to allow for multi-axis movement. I also updated the tests to demonstrate this. 

Fixes #18 