### PR TITLE
Allow `null` for the `MemUnits` property

### DIFF
--- a/src/MoonrakerSharpWebApi.sln
+++ b/src/MoonrakerSharpWebApi.sln
@@ -9,6 +9,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MoonrakerSharpWebApi.Test",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MoonrakerSharpWebApi.SQLite", "MoonrakerSharpWebApi.SQLite\MoonrakerSharpWebApi.SQLite.csproj", "{645D7E22-8A8C-4C12-B06C-F69F94D4DB0B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EE0EE1F9-0768-4AAF-8305-01BBBF36A373}"
+	ProjectSection(SolutionItems) = preProject
+		..\common.props = ..\common.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/MoonrakerSharpWebApi/Models/Moonraker/MoonrakerStatInfo.cs
+++ b/src/MoonrakerSharpWebApi/Models/Moonraker/MoonrakerStatInfo.cs
@@ -15,8 +15,8 @@ namespace AndreasReitberger.API.Moonraker.Models
         [JsonProperty("memory")]
         public long? Memory { get; set; }
 
-        [JsonProperty("mem_units")]
-        public MoonrakerMemUnits MemUnits { get; set; }
+        [JsonProperty("mem_units", NullValueHandling = NullValueHandling.Ignore)]
+        public MoonrakerMemUnits? MemUnits { get; set; }
         #endregion
 
         #region Overrides

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.cs
@@ -28,8 +28,7 @@ namespace AndreasReitberger.API.Moonraker
 {
     // Needs: https://github.com/Arksine/moonraker/blob/master/docs/web_api.md
     // Docs: https://moonraker.readthedocs.io/en/latest/configuration/
-    [ObservableObject]
-    public partial class MoonrakerClient : IDisposable// IRestApiClient
+    public partial class MoonrakerClient : ObservableObject, IDisposable// IRestApiClient
     {
         #region Variables
         RestClient restClient;


### PR DESCRIPTION
This commit changes the `MemUnits` property of the `MoonrakerStatInfo` class to be null.

Fixed #40