### PR TITLE
Fixed webcam uri generation issue with `UserToken`

### DIFF
--- a/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
+++ b/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
@@ -13,7 +13,7 @@ namespace MoonrakerSharpWebApi.Test
 {
     public class Tests
     {
-        private readonly string _host = "192.168.10.44";
+        private readonly string _host = "192.168.10.113";
         private readonly int _port = 80;
         private readonly string _api = "1c8fc5833641429a95d00991e1f3aa0f";
         private readonly bool _ssl = false;

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.cs
@@ -2688,7 +2688,7 @@ namespace AndreasReitberger.API.Moonraker
         {
             try
             {
-                if (WebCamConfigs?.Count <= 0)
+                if (WebCamConfigs?.Count <= 0 || refreshWebCamConfig)
                 {
                     await RefreshWebCamConfigAsync().ConfigureAwait(false);
                 }
@@ -2715,9 +2715,8 @@ namespace AndreasReitberger.API.Moonraker
                         Url = "/webcam?action=stream"
                     };
                 }
-
                 string token = !string.IsNullOrEmpty(ApiKey) ? ApiKey : UserToken;
-                return config == null ? GetDefaultWebCamUri() : $"{FullWebAddress}{config.Url}{(!string.IsNullOrEmpty(token) ? $"?t={token}" : "")}";
+                return config == null ? GetDefaultWebCamUri() : $"{FullWebAddress}{config.Url}{(!string.IsNullOrEmpty(token) ? $"&t={token}" : "")}";
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
This PR fixes an issue where the `UserToken` was added wrongly to the webcam stream afterwards. The `webcams` namespace does exist, after the user has setup the camera and rebooted the system. So there is no issue in that direction. The only problem was the wrongly added token.

Fixed #49