### PR TITLE
Don't throw an `ArgumentOutOfRangeException` by default

### DIFF
--- a/src/MoonrakerSharpWebApi/MoonrakerClient.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.cs
@@ -5464,7 +5464,7 @@ namespace AndreasReitberger.API.Moonraker
             }
         }
 
-        public async Task<Dictionary<string, object>> GetDatabaseItemAsync(string namespaceName, string key = "")
+        public async Task<Dictionary<string, object>> GetDatabaseItemAsync(string namespaceName, string key = "", bool throwOnMissingNamespace = false)
         {
             KlipperApiRequestRespone result = new();
             Dictionary<string, object> resultObject = null;
@@ -5476,7 +5476,12 @@ namespace AndreasReitberger.API.Moonraker
                 }
                 if (!AvailableNamespaces.Contains(namespaceName))
                 {
-                    throw new ArgumentOutOfRangeException(namespaceName, "The requested namespace name was not found in the database!");
+                    if (throwOnMissingNamespace)
+                    {
+                        throw new ArgumentOutOfRangeException(namespaceName, "The requested namespace name was not found in the database!");
+                    }
+                    // If namespace is missing, just return an empty resultObject now
+                    else return resultObject;
                 }
 
                 Dictionary<string, string> urlSegements = new()


### PR DESCRIPTION
This PR changes the behaviour of `GetDatabaseItemAsync` if the requested namespace doesn't exist in the list of `AvailableNamespaces`. Only if forced by the new parameter, an exception will now be thrown.

Fixed #52