### PR TITLE
Switched from `ObservableCollection` to `List` where possible

### DIFF
--- a/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
+++ b/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
@@ -3,14 +3,12 @@ using AndreasReitberger.API.Moonraker.Enum;
 using AndreasReitberger.API.Moonraker.Models;
 using AndreasReitberger.API.Moonraker.Models.WebSocket;
 using AndreasReitberger.API.Print3dServer.Core.Interfaces;
-using AndreasReitberger.API.Print3dServer.Core.JSON.System;
 using AndreasReitberger.Core.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Reflection;
-using System.Security.AccessControl;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
@@ -360,11 +358,11 @@ namespace MoonrakerSharpWebApi.Test
                     await _server.RefreshAllAsync();
                     Assert.That(_server.InitialDataFetched);
 
-                    ObservableCollection<IWebCamConfig> webcamConfigs = await _server.GetWebCamSettingsFromDatabaseAsync();
-                    Assert.That(webcamConfigs.Count > 0);
+                    List<IWebCamConfig>? webcamConfigs = await _server.GetWebCamSettingsFromDatabaseAsync();
+                    Assert.That(webcamConfigs?.Count > 0);
 
                     webcamConfigs = await _server.GetWebCamSettingsAsync();
-                    Assert.That(webcamConfigs.Count > 0);
+                    Assert.That(webcamConfigs?.Count > 0);
 
                     string webcamUri = await _server.GetWebCamUriAsync(0, false);
                     Assert.That(_server.WebCams?.Count > 0);
@@ -513,7 +511,7 @@ namespace MoonrakerSharpWebApi.Test
                         Assert.Fail(args.Message);
                     };
 
-                    ObservableCollection<IGcode> models = await _server.GetAvailableFilesAsync("gcodes", true);
+                    List<IGcode> models = await _server.GetAvailableFilesAsync("gcodes", true);
                     //var childItems = models?.Where(model => model.Path.Contains("/")).ToList();
                     Assert.That(models?.Count > 0);
                     foreach (KlipperFile? gcodeFile in models?.Cast<KlipperFile>()?.Where(g => g?.Meta?.GcodeImages?.Count > 0))
@@ -888,7 +886,7 @@ namespace MoonrakerSharpWebApi.Test
                     await _server.RefreshAllAsync();
                     Assert.That(_server.InitialDataFetched);
 
-                    ObservableCollection<IGcode> files = await _server.GetAvailableFilesAsync();
+                    List<IGcode> files = await _server.GetAvailableFilesAsync();
                     Assert.That(files?.Count > 0);
 
                     string? fileName = files[0]?.FilePath;
@@ -1131,7 +1129,7 @@ namespace MoonrakerSharpWebApi.Test
                         _server.OperatingSystem == MoonrakerOperatingSystems.MainsailOS ? "webcam" : "cameras");
                     Assert.That(webcams?.Count > 0);
 
-                    ObservableCollection<IWebCamConfig> webcamConfig = await _server.GetWebCamSettingsAsync();
+                    List<IWebCamConfig>? webcamConfig = await _server.GetWebCamSettingsAsync();
                     Assert.That(webcamConfig?.Count > 0);
                     if (webcamConfig.Count > 0)
                         Assert.That(!string.IsNullOrEmpty(webcamConfig.FirstOrDefault()?.WebCamUrlDynamic?.ToString()));
@@ -1141,7 +1139,7 @@ namespace MoonrakerSharpWebApi.Test
 
                     if (_server.OperatingSystem == MoonrakerOperatingSystems.MainsailOS)
                     {
-                        KlipperDatabaseMainsailValueHeightmapSettings heightmap = await _server.GetMeshHeightMapSettingsAsync();
+                        KlipperDatabaseMainsailValueHeightmapSettings? heightmap = await _server.GetMeshHeightMapSettingsAsync();
                         Assert.That(heightmap is not null);
                     }
 
@@ -1246,25 +1244,25 @@ namespace MoonrakerSharpWebApi.Test
                     await _server.RefreshAllAsync();
                     Assert.That(_server.InitialDataFetched);
 
-                    KlipperJobQueueResult jobstatus = await _server.GetJobQueueStatusAsync();
+                    KlipperJobQueueResult? jobstatus = await _server.GetJobQueueStatusAsync();
                     Assert.That(jobstatus is not null);
 
-                    ObservableCollection<IGcode> files = await _server.GetAvailableFilesAsync();
+                    List<IGcode> files = await _server.GetAvailableFilesAsync();
                     Assert.That(files?.Count > 0);
 
                     string? fileName = files[0]?.FilePath;
-                    KlipperJobQueueResult queued = await _server.EnqueueJobsAsync(new string[] { fileName });
+                    KlipperJobQueueResult? queued = await _server.EnqueueJobsAsync(new string[] { fileName });
 
                     jobstatus = await _server.GetJobQueueStatusAsync();
                     Assert.That(jobstatus is not null);
 
-                    KlipperJobQueueResult start = await _server.StartJobQueueAsync();
+                    KlipperJobQueueResult? start = await _server.StartJobQueueAsync();
                     Assert.That(start is not null);
 
-                    KlipperJobQueueResult pause = await _server.PauseJobQueueAsync();
+                    KlipperJobQueueResult? pause = await _server.PauseJobQueueAsync();
                     Assert.That(pause is not null);
 
-                    KlipperJobQueueResult removedAll = await _server.RemoveAllJobAsync();
+                    KlipperJobQueueResult? removedAll = await _server.RemoveAllJobAsync();
                     Assert.That(removedAll is not null);
                 }
                 else
@@ -1455,19 +1453,19 @@ namespace MoonrakerSharpWebApi.Test
                     await _server.RefreshAllAsync();
                     Assert.That(_server.InitialDataFetched);
 
-                    ObservableCollection<IPrinter3d> printers = await _server.GetPrintersAsync();
+                    List<IPrinter3d> printers = await _server.GetPrintersAsync();
                     Assert.That(printers?.Count > 0);
 
-                    ObservableCollection<IGcode> gcodes = await _server.GetFilesAsync();
+                    List<IGcode> gcodes = await _server.GetFilesAsync();
                     Assert.That(gcodes?.Count > 0);
 
-                    IToolhead toolheads = await _server.GetExtruderStatusAsync();
+                    IToolhead? toolheads = await _server.GetExtruderStatusAsync();
                     Assert.That(toolheads is not null);
 
-                    IPrint3dFan fan = await _server.GetFanStatusAsync();
+                    IPrint3dFan? fan = await _server.GetFanStatusAsync();
                     Assert.That(fan is not null);
 
-                    IHeaterComponent heaterBed = await _server.GetHeaterBedStatusAsync();
+                    IHeaterComponent? heaterBed = await _server.GetHeaterBedStatusAsync();
                     Assert.That(heaterBed is not null);
                 }
                 else

--- a/src/MoonrakerSharpWebApi/Models/Gcodes/KlipperGcodeMetaResult.cs
+++ b/src/MoonrakerSharpWebApi/Models/Gcodes/KlipperGcodeMetaResult.cs
@@ -1,8 +1,7 @@
 ﻿using AndreasReitberger.API.Print3dServer.Core.Interfaces;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace AndreasReitberger.API.Moonraker.Models
 {
@@ -92,7 +91,7 @@ namespace AndreasReitberger.API.Moonraker.Models
 
         [ObservableProperty, JsonIgnore]
         [property: JsonProperty("thumbnails")]
-        ObservableCollection<IGcodeImage> gcodeImages = [];
+        List<IGcodeImage> gcodeImages = [];
 
         [JsonIgnore]
         public long Layers => GetLayersCount();

--- a/src/MoonrakerSharpWebApi/Models/PrinterStatus/KlipperStatusJob.cs
+++ b/src/MoonrakerSharpWebApi/Models/PrinterStatus/KlipperStatusJob.cs
@@ -68,7 +68,7 @@ namespace AndreasReitberger.API.Moonraker.Models
         [ObservableProperty, JsonIgnore]
         [property: JsonProperty("status")]
         [JsonConverter(typeof(StringEnumConverter), true)]
-        Print3dJobState state;
+        Print3dJobState? state;
 
         [ObservableProperty, JsonIgnore]
         [NotifyPropertyChangedFor(nameof(Done))]

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.Files.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.Files.cs
@@ -57,7 +57,8 @@ namespace AndreasReitberger.API.Moonraker
         {
             try
             {
-                Files = await GetAvailableFilesAsync(rootPath, includeGcodeMeta).ConfigureAwait(false);
+                List<IGcode> files = await GetAvailableFilesAsync(rootPath, includeGcodeMeta).ConfigureAwait(false);
+                Files = [.. files];
             }
             catch (Exception exc)
             {
@@ -66,13 +67,13 @@ namespace AndreasReitberger.API.Moonraker
             }
         }
 
-        public async Task<ObservableCollection<IGcode>> GetAvailableFilesAsync(string rootPath = "", bool includeGcodeMeta = true)
+        public async Task<List<IGcode>> GetAvailableFilesAsync(string rootPath = "", bool includeGcodeMeta = true)
         {
             IRestApiRequestRespone? result = null;
-            ObservableCollection<IGcode> resultObject = new();
+            List<IGcode> resultObject = [];
             try
             {
-                Dictionary<string, string> urlSegments = new();
+                Dictionary<string, string> urlSegments = [];
                 if (!string.IsNullOrEmpty(rootPath))
                 {
                     urlSegments.Add("root", rootPath);
@@ -127,21 +128,10 @@ namespace AndreasReitberger.API.Moonraker
                 return resultObject;
             }
         }
-        public async Task<List<IGcode>> GetAvailableFilesAsListAsync(string rootPath = "")
-        {
-            List<IGcode> resultObject = [];
-            try
-            {
-                ObservableCollection<IGcode> result = await GetAvailableFilesAsync(rootPath).ConfigureAwait(false);
-                return [.. result];
-            }
-            catch (Exception exc)
-            {
-                OnError(new UnhandledExceptionEventArgs(exc, false));
-                return resultObject;
-            }
-        }
-        public override Task<ObservableCollection<IGcode>> GetFilesAsync() => GetAvailableFilesAsync();
+        public Task<List<IGcode>> GetAvailableFilesAsListAsync(string rootPath = "") 
+            => GetAvailableFilesAsync(rootPath);
+
+        public override Task<List<IGcode>> GetFilesAsync() => GetAvailableFilesAsync();
 
         public async Task<KlipperGcodeMetaResult?> GetGcodeMetadataAsync(string fileName)
         {

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.Printers.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.Printers.cs
@@ -60,7 +60,7 @@ namespace AndreasReitberger.API.Moonraker
 
         #region Printer Administration
 
-        public override async Task<ObservableCollection<IPrinter3d>> GetPrintersAsync()
+        public override async Task<List<IPrinter3d>> GetPrintersAsync()
         {
             await Task.Delay(1);
             return [];

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.WebCam.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.WebCam.cs
@@ -33,13 +33,13 @@ namespace AndreasReitberger.API.Moonraker
 
         #region Methods
 
-        public override Task<ObservableCollection<IWebCamConfig>> GetWebCamConfigsAsync() => GetWebCamSettingsAsync();
+        public override Task<List<IWebCamConfig>?> GetWebCamConfigsAsync() => GetWebCamSettingsAsync();
 
-        public async Task<ObservableCollection<IWebCamConfig>> GetWebCamSettingsAsync()
+        public async Task<List<IWebCamConfig>?> GetWebCamSettingsAsync()
         {
             string resultString = string.Empty;
             IRestApiRequestRespone? result = null;
-            ObservableCollection<IWebCamConfig> resultObject = new();
+            List<IWebCamConfig> resultObject = [];
             try
             {
                 string targetUri = $"{MoonrakerCommands.Server}";
@@ -78,10 +78,10 @@ namespace AndreasReitberger.API.Moonraker
             }
         }
 
-        public async Task<ObservableCollection<IWebCamConfig>> GetWebCamSettingsFromDatabaseAsync()
+        public async Task<List<IWebCamConfig>> GetWebCamSettingsFromDatabaseAsync()
         {
             string? resultString = string.Empty;
-            ObservableCollection<IWebCamConfig> resultObject = new();
+            List<IWebCamConfig> resultObject = [];
             try
             {
                 // Both operating systems handles their datababase namespaces and keys differently....
@@ -151,7 +151,7 @@ namespace AndreasReitberger.API.Moonraker
         {
             try
             {
-                ObservableCollection<IWebCamConfig> result = await GetWebCamSettingsAsync().ConfigureAwait(false);
+                List<IWebCamConfig>? result = await GetWebCamSettingsAsync().ConfigureAwait(false);
                 WebCams = [.. result];
             }
             catch (Exception exc)


### PR DESCRIPTION
This PR replaces `ObservableCollection` with `List` return types where possible.

Fixed #114