### PR TITLE
KlipperIdleStates Fixup

### DIFF
--- a/common.props
+++ b/common.props
@@ -9,7 +9,7 @@
         <PackageReleaseNotes>Check GitHub releases for changelog.</PackageReleaseNotes>
         <Authors>Andreas Reitberger</Authors>
         <Copyright>Andreas Reitberger</Copyright>
-        <LangVersion>12</LangVersion>
+		<LangVersion>preview</LangVersion>
         <PublishReadyToRun>false</PublishReadyToRun>
 		<Nullable>enable</Nullable>
 

--- a/src/MoonrakerSharpWebApi/Enums/KlipperIdleStates.cs
+++ b/src/MoonrakerSharpWebApi/Enums/KlipperIdleStates.cs
@@ -11,6 +11,6 @@ namespace AndreasReitberger.API.Moonraker.Enum
         [EnumMember(Value = "Printing")]
         Printing = 2,
         [EnumMember(Value = "Shutdown")]
-        Shutdown = 2,
+        Shutdown = 3,
     }
 }


### PR DESCRIPTION
Fixed KlipperIdleStates, because there is a syntax error when you try to pass through current printer statuses in switch-case loop