### PR TITLE
Added job interruption status

### DIFF
--- a/src/MoonrakerSharpWebApi/Enums/KlipperJobStates.cs
+++ b/src/MoonrakerSharpWebApi/Enums/KlipperJobStates.cs
@@ -12,6 +12,8 @@ namespace AndreasReitberger.API.Moonraker.Enum
         InProgress = 2,
         [EnumMember(Value = "cancelled")]
         Cancelled = 3,
+        [EnumMember(Value = "interrupted")]
+        Interrupted = 4,
         [EnumMember(Value = "error")]
         Error = 99,
     }


### PR DESCRIPTION
Hi Andreas!
Moonraker has been updated a few months ago and there was new job status added. Found that deserializer is getting failed to process response with it. [Watch this](https://github.com/Arksine/moonraker/blob/4e00a0760e756872b2fbb23a82b88dbceb383cf4/docs/changelog.md?plain=1#L70)

Here are some reports:

![Report](https://github.com/user-attachments/assets/48635074-7bb5-41cb-b904-5395ba640f5b)

![Report2](https://github.com/user-attachments/assets/e7054561-b2a0-411d-853b-96f09de84d48)

Also found that version 1.3 is working fine with processing requests to the server opposite moment that i mentioned above. So i tried 1.3.1-prev2 nuget package and it fails on every response because something wrong with auth in Print3dCore lib. Server rejects every response with code 401 but i havent changed anything in my project. Do you have any fresh version of 1.3.1 package?
