### PR TITLE
Fixed wrong `Http.Methods`

### DIFF
--- a/src/MoonrakerSharpWebApi/MoonrakerClient.Database.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.Database.cs
@@ -35,7 +35,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "database/list",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegments,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -105,7 +104,6 @@ namespace AndreasReitberger.API.Moonraker
                     // If namespace is missing, just return an empty resultObject now
                     else return resultObject;
                 }
-
                 Dictionary<string, string> urlSegments = new()
                 {
                     { "namespace", namespaceName }

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.Printers.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.Printers.cs
@@ -86,8 +86,6 @@ namespace AndreasReitberger.API.Moonraker
             KlipperPrinterStateMessageResult? resultObject = null;
             try
             {
-                //object cmd = new { name = ScriptName };
-
                 string targetUri = $"{MoonrakerCommands.Printer}";
                 result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
@@ -95,7 +93,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "info",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -128,8 +125,6 @@ namespace AndreasReitberger.API.Moonraker
         {
             try
             {
-                //object cmd = new { name = ScriptName };
-
                 string targetUri = $"{MoonrakerCommands.Printer}";
                 IRestApiRequestRespone? result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
@@ -137,7 +132,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "emergency_stop",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -159,7 +153,6 @@ namespace AndreasReitberger.API.Moonraker
         {
             try
             {
-                //object cmd = new { name = ScriptName };
                 string targetUri = $"{MoonrakerCommands.Printer}";
                 IRestApiRequestRespone? result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
@@ -167,7 +160,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "restart",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -189,7 +181,6 @@ namespace AndreasReitberger.API.Moonraker
         {
             try
             {
-                //object cmd = new { name = ScriptName };
                 string targetUri = $"{MoonrakerCommands.Printer}";
                 IRestApiRequestRespone? result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
@@ -197,7 +188,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "firmware_restart",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -319,7 +309,6 @@ namespace AndreasReitberger.API.Moonraker
             List<string> resultObject = [];
             try
             {
-                //object cmd = new { name = ScriptName };
                 string targetUri = $"{MoonrakerCommands.Printer}";
                 result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
@@ -327,7 +316,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "objects/list",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -1268,7 +1256,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "query_endstops/status",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.WebCam.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.WebCam.cs
@@ -32,7 +32,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "webcams/list",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegments,
                        cts: default
                        )
                     .ConfigureAwait(false);

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.cs
@@ -1350,7 +1350,7 @@ namespace AndreasReitberger.API.Moonraker
                 string targetUri = $"{MoonrakerCommands.Printer}";
                 result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
-                       method: Method.Post,
+                       method: Method.Get,
                        command: "gcode/help",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
@@ -1568,7 +1568,7 @@ namespace AndreasReitberger.API.Moonraker
                 string targetUri = $"{MoonrakerCommands.Machine}";
                 result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
-                       method: Method.Post,
+                       method: Method.Get,
                        command: "system_info",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
@@ -2873,7 +2873,7 @@ namespace AndreasReitberger.API.Moonraker
         public async Task<Dictionary<string, string>> SetDeviceStateAsync(string device, KlipperDeviceActions action)
         {
             IRestApiRequestRespone? result = null;
-            Dictionary<string, string> resultObject = new();
+            Dictionary<string, string> resultObject = [];
             try
             {
                 Dictionary<string, string> urlSegments = new()
@@ -2975,7 +2975,7 @@ namespace AndreasReitberger.API.Moonraker
         public async Task<Dictionary<string, string>> SetBatchDeviceOnAsync(string[] devices)
         {
             IRestApiRequestRespone? result = null;
-            Dictionary<string, string> resultObject = new();
+            Dictionary<string, string> resultObject = [];
             try
             {
                 StringBuilder deviceList = new();
@@ -3367,7 +3367,7 @@ namespace AndreasReitberger.API.Moonraker
             }
         }
 
-        public Task<bool> SendOctoPrintApiGcodeCommandAsync(string command) => SendOctoPrintApiGcodeCommandAsync(new string[] { command });
+        public Task<bool> SendOctoPrintApiGcodeCommandAsync(string command) => SendOctoPrintApiGcodeCommandAsync([command]);
 
         public async Task<Dictionary<string, OctoprintApiPrinter>> GetOctoPrintApiPrinterProfilesAsync()
         {
@@ -3492,7 +3492,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: $"history/totals",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegments,
                        cts: default
                        )
                     .ConfigureAwait(false);


### PR DESCRIPTION
This PR fixes wrong `Http.Methods` (it was set `POST`, but needed `GET` and vice reverse).

Fixed #138