### PR TITLE
Added tests for `Auth` without `ApiKey`

### DIFF
--- a/src/MoonrakerSharpWebApi.SQLite/MoonrakerSharpWebApi.SQLite.csproj
+++ b/src/MoonrakerSharpWebApi.SQLite/MoonrakerSharpWebApi.SQLite.csproj
@@ -13,6 +13,7 @@
 	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <Title>MoonrakerSharpWebApi.SQLite</Title>
+	  <UserSecretsId>2fcb2e15-a623-46ce-91ea-5913ca527be9</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
+++ b/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
@@ -49,6 +49,66 @@ namespace MoonrakerSharpWebApi.Test
         }
 
         [Test]
+        public async Task BuildWitOneShotTokenAsync()
+        {
+            try
+            {
+                var client = new MoonrakerClient.MoonrakerConnectionBuilder()
+                    .WithName("Test")
+                    .WithServerAddress(_host, _port, _ssl)
+                    .Build();
+                KlipperAccessTokenResult? token = await client.GetOneshotTokenAsync();
+
+                client.OneShotToken = token?.Result ?? string.Empty;
+                Assert.That(!string.IsNullOrEmpty(client.OneShotToken));
+
+                KlipperMachineInfo? info = await client.GetMachineSystemInfoAsync();
+                Assert.That(info is not null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        [Test]
+        public async Task BuildWitUserTokenAsync()
+        {
+            try
+            {
+                var client = new MoonrakerClient.MoonrakerConnectionBuilder()
+                    .WithName("Test")
+                    .WithServerAddress(_host, _port, _ssl)
+                    .Build();
+                string? apiKey = await client.LoginUserForApiKeyAsync("user", "pwd");
+
+                /*
+                 * Set by the LoginUserAsync() method
+                 * UserToken = queryResult?.Result?.Token ?? string.Empty;
+                 * RefreshToken = queryResult?.Result?.RefreshToken ?? string.Empty;
+                 */
+                Assert.That(!string.IsNullOrEmpty(client.UserToken));
+                Assert.That(!string.IsNullOrEmpty(client.RefreshToken));
+
+                // This should be enough to authenticate.
+                KlipperMachineInfo? info = await client.GetMachineSystemInfoAsync();
+                Assert.That(info is not null);
+
+                client.AuthHeaders.Clear();
+                // Also try with the api key to verify
+                client.ApiKey = apiKey ?? string.Empty;
+                Assert.That(!string.IsNullOrEmpty(client.ApiKey));
+
+                info = await client.GetMachineSystemInfoAsync();
+                Assert.That(info is not null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        [Test]
         public void SerializeJsonTest()
         {
             var dir = @"TestResults\Serialization\";

--- a/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
+++ b/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
@@ -96,11 +96,26 @@ namespace MoonrakerSharpWebApi.Test
                 // This should be enough to authenticate.
                 KlipperMachineInfo? info = await client.GetMachineSystemInfoAsync();
                 Assert.That(info is not null);
+                info = null;
+
+                // Remove the api key to test if the UserToken works as well
+                var lastHeader = client.AuthHeaders.Last();
+                client.AuthHeaders.Remove(lastHeader.Key);
+
+                info = await client.GetMachineSystemInfoAsync();
+                Assert.That(info is not null);
 
                 client.AuthHeaders.Clear();
+                client.ApiKey = "";
+
                 // Also try with the api key to verify
                 client.ApiKey = apiKey ?? string.Empty;
                 Assert.That(!string.IsNullOrEmpty(client.ApiKey));
+
+                info = await client.GetMachineSystemInfoAsync();
+                Assert.That(info is not null);
+
+                await client.LogoutCurrentUserAsync();
 
                 info = await client.GetMachineSystemInfoAsync();
                 Assert.That(info is not null);

--- a/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
+++ b/src/MoonrakerSharpWebApi.Test/MoonrakerSharpWebApi.Test.cs
@@ -19,6 +19,8 @@ namespace MoonrakerSharpWebApi.Test
         private readonly string _host = SecretAppSettingReader.ReadSection<SecretAppSetting>("TestSetup").Ip ?? "";
         private readonly int _port = 80;
         private readonly string _api = SecretAppSettingReader.ReadSection<SecretAppSetting>("TestSetup").ApiKey ?? "";
+        private readonly string _user = SecretAppSettingReader.ReadSection<SecretAppSetting>("TestSetup").Username ?? "";
+        private readonly string _pwd = SecretAppSettingReader.ReadSection<SecretAppSetting>("TestSetup").Password ?? "";
         private readonly bool _ssl = false;
 
         private readonly bool _skipOnlineTests = true;
@@ -76,11 +78,12 @@ namespace MoonrakerSharpWebApi.Test
         {
             try
             {
+                Assert.That(!string.IsNullOrEmpty(_user) && !string.IsNullOrEmpty(_pwd), "Provide a user and password in your secrets.json file first!");
                 var client = new MoonrakerClient.MoonrakerConnectionBuilder()
                     .WithName("Test")
                     .WithServerAddress(_host, _port, _ssl)
                     .Build();
-                string? apiKey = await client.LoginUserForApiKeyAsync("user", "pwd");
+                string? apiKey = await client.LoginUserForApiKeyAsync(_user, _pwd);
 
                 /*
                  * Set by the LoginUserAsync() method

--- a/src/MoonrakerSharpWebApi.Test/SecretAppSetting.cs
+++ b/src/MoonrakerSharpWebApi.Test/SecretAppSetting.cs
@@ -4,5 +4,7 @@
     {
         public string? ApiKey { get; set; }
         public string? Ip { get; set; }
+        public string? Username { get; set; }
+        public string? Password { get; set; }
     }
 }

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.Auth.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.Auth.cs
@@ -8,6 +8,13 @@ namespace AndreasReitberger.API.Moonraker
     public partial class MoonrakerClient
     {
         #region Auth
+        /*
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        new string apiKey = string.Empty;
+        partial void OnApiKeyChanged(string value) => AddOrUpdateAuthHeader("usertoken", value);
+        */
+        
 
         [ObservableProperty]
         [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.Files.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.Files.cs
@@ -35,7 +35,7 @@ namespace AndreasReitberger.API.Moonraker
 
         [ObservableProperty]
         [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
-        ObservableCollection<KlipperDirectory> availableDirectories = new();
+        ObservableCollection<KlipperDirectory> availableDirectories = [];
         partial void OnAvailableDirectoriesChanged(ObservableCollection<KlipperDirectory> value)
         {
             /*

--- a/src/MoonrakerSharpWebApi/MoonrakerClient.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerClient.cs
@@ -8,15 +8,12 @@ using AndreasReitberger.API.Print3dServer.Core.Events;
 using AndreasReitberger.API.Print3dServer.Core.Interfaces;
 using AndreasReitberger.Core.Utilities;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Net.Http;
 using System.Security;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -961,7 +958,6 @@ namespace AndreasReitberger.API.Moonraker
             KlipperAccessTokenResult? resultObject = null;
             try
             {
-                //object cmd = new { name = ScriptName };
                 string targetUri = $"{MoonrakerCommands.Access}";
                 result = await SendRestApiRequestAsync(
                        requestTargetUri: targetUri,
@@ -969,7 +965,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "oneshot_token",
                        jsonObject: null,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegements,
                        cts: default
                        )
                     .ConfigureAwait(false);
@@ -1827,7 +1822,6 @@ namespace AndreasReitberger.API.Moonraker
                        command: "login",
                        jsonObject: cmd,
                        authHeaders: AuthHeaders,
-                       //urlSegments: urlSegments,
                        cts: default
                        )
                     .ConfigureAwait(false);

--- a/src/MoonrakerSharpWebApi/MoonrakerConnectionBuilder.cs
+++ b/src/MoonrakerSharpWebApi/MoonrakerConnectionBuilder.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using AndreasReitberger.API.Moonraker.Models;
+using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace AndreasReitberger.API.Moonraker
 {
@@ -34,6 +36,27 @@ namespace AndreasReitberger.API.Moonraker
                 _client.ApiKey = apiKey;
                 return this;
             }
+
+            /*
+            public async Task<MoonrakerConnectionBuilder> WithUserTokenAsync(string? userToken = null)
+            {
+                if (userToken is null)
+                {
+                    KlipperAccessTokenResult? tokenResult = await _client.GetOneshotTokenAsync();
+                    userToken = tokenResult?.Result;
+                }
+                _client.OneShotToken = userToken ?? string.Empty;
+                return this;
+            }
+
+            public async Task<MoonrakerConnectionBuilder> WitLoginAsync(string username, string password)
+            {
+                string apiToken = await _client.LoginUserForApiKeyAsync(username, password);
+                _client.ApiKey = apiToken;
+                await _client.LogoutCurrentUserAsync();
+                return this;
+            }
+            */
 
             public MoonrakerConnectionBuilder WithName(string name)
             {


### PR DESCRIPTION
This PR adds tests to check if the authentiaction also works if no `ApiKey` was provided, as it did in `1.3.0`.

Fixed #137