### PR TITLE
Missed statuses added and CpuTemp deserialization fixed

### DIFF
--- a/src/MoonrakerSharpWebApi/Enums/KlipperJobStates.cs
+++ b/src/MoonrakerSharpWebApi/Enums/KlipperJobStates.cs
@@ -8,12 +8,16 @@ namespace AndreasReitberger.API.Moonraker.Enum
         Completed = 0,
         [EnumMember(Value = "klippy_shutdown")]
         KlippyShutdown = 1,
+        [EnumMember(Value = "klippy_disconnect")]
+        KlippyDisconnect = 2,
         [EnumMember(Value = "in_progress")]
-        InProgress = 2,
+        InProgress = 3,
         [EnumMember(Value = "cancelled")]
-        Cancelled = 3,
+        Cancelled = 4,
         [EnumMember(Value = "interrupted")]
-        Interrupted = 4,
+        Interrupted = 5,
+        [EnumMember(Value = "server_exit")]
+        ServerExit = 6,
         [EnumMember(Value = "error")]
         Error = 99,
     }

--- a/src/MoonrakerSharpWebApi/Models/Moonraker/KlipperMoonrakerProcessStatsResult.cs
+++ b/src/MoonrakerSharpWebApi/Models/Moonraker/KlipperMoonrakerProcessStatsResult.cs
@@ -19,7 +19,7 @@ namespace AndreasReitberger.API.Moonraker.Models
         [ObservableProperty]
 
         [JsonProperty("cpu_temp")]
-        public partial double CpuTemp { get; set; }
+        public partial double? CpuTemp { get; set; }
 
         [ObservableProperty]
 


### PR DESCRIPTION
Hi, @AndreasReitberger
This is another small PR from me with some bug fixes :)

1. Moonraker can return null in cpu_temp json object so this field in KlipperMoonrakerProcessStatsResult should be nullable for right deserialization.

![CpuTemp](https://github.com/user-attachments/assets/1e391438-d7a9-4d65-bd77-01a2b0689cf8)

2. Some missed KlipperJobStates added.

![JobStatus1](https://github.com/user-attachments/assets/f70bbd51-b053-43ab-a6c7-a592df02d42c)

![JobStatus2](https://github.com/user-attachments/assets/8e7bcec4-f04b-4c3d-a52a-ee5327b0ddd8)
